### PR TITLE
Add the last convolution layer to the HigherArchicalHeteroGraphSage

### DIFF
--- a/graphmuse/nn/models/metrical_gnn.py
+++ b/graphmuse/nn/models/metrical_gnn.py
@@ -59,6 +59,7 @@ class HierarchicalHeteroGraphSage(torch.nn.Module):
                 x=x_dict,
                 edge_index=edge_index_dict,
             )
+        x_dict = self.convs[-1](x_dict, edge_index_dict)
         return x_dict
 
 


### PR DESCRIPTION
I noticed that the last convolution layer defined in `__init__()` was not being utilized in the `forward()` function. To resolve this, I added a single line: `x_dict = self.convs[-1](x_dict, edge_index_dict)`.