### PR TITLE
Update documentation and variable names in models

### DIFF
--- a/graphmuse/nn/conv/gcn.py
+++ b/graphmuse/nn/conv/gcn.py
@@ -1,23 +1,59 @@
 import torch
 import torch.nn as nn
 
-# TODO check for correctness.
 class GraphConv(nn.Module):
-    """GCN implementation."""
-    def __init__(self, in_dim, out_dim, dropout, bias=True):
+    """
+    Graph Convolutional Network (GCN) layer implementation.
+
+    Parameters
+    ----------
+    input_channels : int
+        Number of input channels.
+    output_channels : int
+        Number of output channels.
+    dropout : float
+        Dropout rate.
+    bias : bool, optional
+        Whether to include a bias term, by default True.
+
+    Examples
+    --------
+    >>> gcn_layer = GraphConv(input_channels=16, output_channels=8, dropout=0.5)
+    >>> h = torch.randn(10, 16)
+    >>> adj = torch.randint(0, 2, (10, 10))
+    >>> out = gcn_layer(h, adj)
+    >>> print(out.shape)
+    torch.Size([10, 8])
+    """
+    def __init__(self, input_channels, output_channels, dropout, bias=True):
         super(GraphConv, self).__init__()
-        self.in_dim = in_dim
-        self.out_dim = out_dim
+        self.input_channels = input_channels
+        self.output_channels = output_channels
         self.dropout = dropout
         self.bias = bias
 
-        self.W = nn.Parameter(torch.zeros(size=(in_dim, out_dim)))
+        self.W = nn.Parameter(torch.zeros(size=(input_channels, output_channels)))
         nn.init.xavier_uniform_(self.W.data, gain=1.414)
         if self.bias:
-            self.b = nn.Parameter(torch.zeros(size=(out_dim,)))
+            self.b = nn.Parameter(torch.zeros(size=(output_channels,)))
             nn.init.xavier_uniform_(self.b.data, gain=1.414)
 
     def forward(self, h, adj):
+        """
+        Forward pass for the Graph Convolutional Network (GCN) layer.
+
+        Parameters
+        ----------
+        h : torch.Tensor
+            Input node features.
+        adj : torch.Tensor
+            Adjacency matrix.
+
+        Returns
+        -------
+        torch.Tensor
+            Output node features.
+        """
         Wh = torch.mm(h, self.W)
         h_prime = torch.matmul(adj, Wh)
         if self.bias:
@@ -27,5 +63,5 @@ class GraphConv(nn.Module):
 
     def __repr__(self):
         return self.__class__.__name__ + ' (' \
-            + str(self.in_dim) + ' -> ' \
-            + str(self.out_dim) + ')'
+            + str(self.input_channels) + ' -> ' \
+            + str(self.output_channels) + ')'

--- a/graphmuse/nn/conv/ggru.py
+++ b/graphmuse/nn/conv/ggru.py
@@ -9,23 +9,59 @@ class GGRU(nn.Module):
     A GRU inspired implementation of a GCN cell.
 
     h(t-1) in this case is the neighbors of node t.
+
+    Parameters
+    ----------
+    input_channels : int
+        Number of input channels.
+    output_channels : int
+        Number of output channels.
+    bias : bool, optional
+        Whether to include a bias term, by default False.
+
+    Examples
+    --------
+    >>> ggru_layer = GGRU(input_channels=16, output_channels=8, bias=True)
+    >>> x = torch.randn(10, 16)
+    >>> adj = torch.randint(0, 2, (10, 10))
+    >>> out = ggru_layer(x, adj)
+    >>> print(out.shape)
+    torch.Size([10, 8])
     """
-    def __init__(self, in_features, out_features, bias=False):
+    def __init__(self, input_channels, output_channels, bias=False):
         super(GGRU, self).__init__()
-        self.wr = SageConvLayer(in_features, in_features)
-        self.wz = SageConvLayer(in_features, out_features)
-        self.w_ni = nn.Linear(in_features*2, out_features)
-        self.w_nh = nn.Linear(in_features, in_features)
-        self.proj = nn.Linear(in_features, out_features)
+        self.wr = SageConvLayer(input_channels, input_channels)
+        self.wz = SageConvLayer(input_channels, output_channels)
+        self.w_ni = nn.Linear(input_channels*2, output_channels)
+        self.w_nh = nn.Linear(input_channels, input_channels)
+        self.proj = nn.Linear(input_channels, output_channels)
         self.reset_parameters()
 
     def reset_parameters(self):
+        """
+        Reset the parameters of the GGRU layer.
+        """
         gain = nn.init.calculate_gain("relu")
         nn.init.xavier_uniform_(self.w_ni.weight, gain=gain)
         nn.init.xavier_uniform_(self.w_nh.weight, gain=gain)
         nn.init.xavier_uniform_(self.proj.weight, gain=gain)
 
     def forward(self, x, adj):
+        """
+        Forward pass for the GGRU layer.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input node features.
+        adj : torch.Tensor
+            Adjacency matrix.
+
+        Returns
+        -------
+        torch.Tensor
+            Output node features.
+        """
         h = x
         r = F.sigmoid(self.wr(h, adj))
         z = F.sigmoid(self.wz(h, adj))

--- a/graphmuse/nn/conv/metrical_conv.py
+++ b/graphmuse/nn/conv/metrical_conv.py
@@ -77,6 +77,7 @@ class MetricalConvLayer(nn.Module):
         else:
             seq_index = []
             lengths = torch.unique(batch, return_counts=True)[1]
+            # add zero to the beginning of lengths
             lengths = torch.cat((torch.zeros(1, dtype=torch.long), lengths))
             lengths_cummulative = torch.cumsum(lengths, dim=0)
             for i in range(len(lengths) - 1):

--- a/graphmuse/nn/conv/sage.py
+++ b/graphmuse/nn/conv/sage.py
@@ -3,13 +3,37 @@ import torch
 
 
 class SageConvLayer(nn.Module):
-    def __init__(self, in_features, out_features, bias=False):
+    """
+    GraphSAGE Convolutional Layer.
+
+    Parameters
+    ----------
+    input_channels : int
+        Number of input channels.
+    output_channels : int
+        Number of output channels.
+    bias : bool, optional
+        Whether to include a bias term, by default False.
+
+    Examples
+    --------
+    >>> layer = SageConvLayer(input_channels=16, output_channels=32)
+    >>> features = torch.randn(10, 16)
+    >>> adj = torch.randint(0, 2, (10, 10))
+    >>> output = layer.forward_adj(features, adj)
+    >>> print(output.shape)
+    torch.Size([10, 32])
+    """
+    def __init__(self, input_channels, output_channels, bias=False):
         super(SageConvLayer, self).__init__()
-        self.neigh_linear = nn.Linear(in_features, in_features, bias=bias)
-        self.linear = nn.Linear(in_features * 2, out_features, bias=bias)
+        self.neigh_linear = nn.Linear(input_channels, input_channels, bias=bias)
+        self.linear = nn.Linear(input_channels * 2, output_channels, bias=bias)
         self.reset_parameters()
 
     def reset_parameters(self):
+        """
+        Reset the parameters of the SageConvLayer.
+        """
         gain = nn.init.calculate_gain('relu')
         nn.init.xavier_uniform_(self.linear.weight, gain=gain)
         nn.init.xavier_uniform_(self.neigh_linear.weight, gain=gain)
@@ -20,7 +44,7 @@ class SageConvLayer(nn.Module):
 
     def forward_adj(self, features, adj, neigh_feats=None):
         """
-        This is the forward pass for the rectangle version of adjacency.
+        Forward pass for the SageConvLayer using adjacency matrix.
 
         Parameters
         ----------
@@ -28,6 +52,13 @@ class SageConvLayer(nn.Module):
             The node features.
         adj : torch.LongTensor
             The edge indices size (N Neighbors, M Target).
+        neigh_feats : torch.Tensor, optional
+            The neighbor features, by default None.
+
+        Returns
+        -------
+        torch.Tensor
+            The output features.
         """
         if neigh_feats is None:
             neigh_feats = features

--- a/graphmuse/nn/models/cadence.py
+++ b/graphmuse/nn/models/cadence.py
@@ -6,44 +6,89 @@ import torch_scatter
 
 
 class CadenceGNN(nn.Module):
-    def __init__(self, metadata, input_dim, hidden_dim, output_dim, num_layers, dropout=0.5, hybrid=False):
+    """
+    CadenceGNN is a graph neural network model for cadence detection in music.
+
+    Parameters
+    ----------
+    metadata : dict
+        Metadata for the graph.
+    input_channels : int
+        Number of input channels.
+    hidden_channels : int
+        Number of hidden channels.
+    output_channels : int
+        Number of output channels.
+    num_layers : int
+        Number of layers in the GNN.
+    dropout : float, optional
+        Dropout rate, by default 0.5.
+    hybrid : bool, optional
+        Whether to use a hybrid model with RNN, by default False.
+
+    Examples
+    --------
+    >>> metadata = {"note": {"x": torch.randn(10, 16)}}
+    >>> model = CadenceGNN(metadata, input_channels=16, hidden_channels=32, output_channels=2, num_layers=3)
+    >>> x_dict = {"note": torch.randn(10, 16)}
+    >>> edge_index_dict = {"note": {"note": torch.randint(0, 10, (2, 20))}}
+    >>> out = model(x_dict, edge_index_dict)
+    >>> print(out.shape)
+    torch.Size([10, 2])
+    """
+    def __init__(self, metadata, input_channels, hidden_channels, output_channels, num_layers, dropout=0.5, hybrid=False):
         super(CadenceGNN, self).__init__()
         self.gnn = MetricalGNN(
-            input_dim=input_dim, hidden_dim=hidden_dim, output_dim=hidden_dim // 2,
+            input_channels=input_channels, hidden_channels=hidden_channels, output_channels=hidden_channels // 2,
             num_layers=num_layers, metadata=metadata, dropout=dropout)
 
-        hidden_dim = hidden_dim // 2
-        self.norm = nn.LayerNorm(hidden_dim)
+        hidden_channels = hidden_channels // 2
+        self.norm = nn.LayerNorm(hidden_channels)
         self.hybrid = hybrid
         if self.hybrid:
             self.rnn = nn.GRU(
-                input_size=input_dim, hidden_size=hidden_dim//2, num_layers=2, batch_first=True, bidirectional=True,
+                input_size=input_channels, hidden_size=hidden_channels//2, num_layers=2, batch_first=True, bidirectional=True,
                 dropout=dropout)
-            self.rnn_norm = nn.LayerNorm(hidden_dim)
+            self.rnn_norm = nn.LayerNorm(hidden_channels)
             self.rnn_mlp = nn.Sequential(
-                nn.Linear(hidden_dim, hidden_dim),
+                nn.Linear(hidden_channels, hidden_channels),
                 nn.ReLU(),
-                nn.LayerNorm(hidden_dim),
+                nn.LayerNorm(hidden_channels),
                 nn.Dropout(dropout),
-                nn.Linear(hidden_dim, hidden_dim),
+                nn.Linear(hidden_channels, hidden_channels),
             )
-            self.cat_proj = nn.Linear(hidden_dim*2, hidden_dim)
+            self.cat_proj = nn.Linear(hidden_channels*2, hidden_channels)
         self.pool_mlp = nn.Sequential(
-            nn.Linear(hidden_dim, hidden_dim),
+            nn.Linear(hidden_channels, hidden_channels),
             nn.ReLU(),
-            nn.LayerNorm(hidden_dim),
+            nn.LayerNorm(hidden_channels),
             nn.Dropout(dropout),
-            nn.Linear(hidden_dim, hidden_dim),
+            nn.Linear(hidden_channels, hidden_channels),
         )
         self.cad_clf = nn.Sequential(
-            nn.Linear(hidden_dim, hidden_dim // 2),
+            nn.Linear(hidden_channels, hidden_channels // 2),
             nn.ReLU(),
-            nn.BatchNorm1d(hidden_dim // 2),
+            nn.BatchNorm1d(hidden_channels // 2),
             nn.Dropout(dropout),
-            nn.Linear(hidden_dim // 2, output_dim),
+            nn.Linear(hidden_channels // 2, output_channels),
         )
 
     def hybrid_forward(self, x, batch):
+        """
+        Forward pass for the hybrid model with RNN.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input node features.
+        batch : torch.Tensor
+            Batch indices.
+
+        Returns
+        -------
+        torch.Tensor
+            Output node features.
+        """
         lengths = torch.bincount(batch)
         x = x.split(lengths.tolist())
         x = nn.utils.rnn.pad_sequence(x, batch_first=True, padding_value=0.0)
@@ -55,10 +100,32 @@ class CadenceGNN(nn.Module):
         return x
 
     def encode(self, x_dict, edge_index_dict, neighbor_mask_node, neighbor_mask_edge, batch_note=None, onset_div=None):
+        """
+        Encode the input graph data.
+
+        Parameters
+        ----------
+        x_dict : dict
+            Dictionary of input node features.
+        edge_index_dict : dict
+            Dictionary of edge indices.
+        neighbor_mask_node : dict
+            Dictionary of neighbor masks for nodes.
+        neighbor_mask_edge : dict
+            Dictionary of neighbor masks for edges.
+        batch_note : torch.Tensor, optional
+            Batch indices for notes, by default None.
+        onset_div : torch.Tensor, optional
+            Onset divisions, by default None.
+
+        Returns
+        -------
+        torch.Tensor
+            Encoded node features.
+        """
         if batch_note is None:
             batch_note = torch.zeros((x_dict["note"].shape[0], ), device=x_dict["note"].device).long()
         if onset_div is None:
-            # check if onset_div is present in x_dict
             if "onset_div" in x_dict:
                 onset_div = x_dict.pop("onset_div")
         x = self.gnn(
@@ -66,25 +133,19 @@ class CadenceGNN(nn.Module):
         if self.hybrid:
             z = self.hybrid_forward(x_dict["note"][neighbor_mask_node["note"] == 0], batch_note[neighbor_mask_node["note"] == 0])
             x = self.cat_proj(torch.cat((x, z), dim=-1))
-        # repr_pred = self.repr_mlp(x)
         if onset_div is not None:
-            # This is a pooling operation that aggregates the features of notes with the same onset
             batch_note = batch_note[neighbor_mask_node["note"] == 0]
             onset_div = onset_div[neighbor_mask_node["note"] == 0]
             a = torch.stack((batch_note, onset_div), dim=-1)
             unique, cluster = torch.unique(a, return_inverse=True, dim=0, sorted=True)
             multiplicity = torch.ones_like(batch_note)
-            # mean the features of notes with the same onset
             x = torch.zeros(unique.size(0), x.size(1), device=x.device).scatter_add(0, cluster.unsqueeze(1).expand(-1, x.size(1)), x)
             multiplicity = torch.zeros(unique.size(0), device=x.device, dtype=torch.long).scatter_add(0, cluster, multiplicity)
             x = x / multiplicity.unsqueeze(1)
-            # repr_out = self.repr_mlp(x)
             x = self.norm(x)
             x = self.pool_mlp(x)
             x = x[cluster]
-            # repr_loss = F.mse_loss(repr_out, repr_pred)
         else:
-        # NOTE: Remove above lines and replace with the following:
             onset_index = edge_index_dict["note", "onset", "note"]
             x = torch_scatter.scatter_mean(x[onset_index[0]], onset_index[1], dim=0, out=x.clone())
             x = self.norm(x)
@@ -92,6 +153,25 @@ class CadenceGNN(nn.Module):
         return x
 
     def forward(self, x_dict, edge_index_dict, neighbor_mask_node=None, neighbor_mask_edge=None):
+        """
+        Forward pass for the CadenceGNN model.
+
+        Parameters
+        ----------
+        x_dict : dict
+            Dictionary of input node features.
+        edge_index_dict : dict
+            Dictionary of edge indices.
+        neighbor_mask_node : dict, optional
+            Dictionary of neighbor masks for nodes, by default None.
+        neighbor_mask_edge : dict, optional
+            Dictionary of neighbor masks for edges, by default None.
+
+        Returns
+        -------
+        torch.Tensor
+            Output node features.
+        """
         if neighbor_mask_node is None:
             neighbor_mask_node = {k: torch.zeros((x_dict[k].shape[0], ), device=x_dict[k].device).long() for k in x_dict}
         if neighbor_mask_edge is None:
@@ -101,4 +181,17 @@ class CadenceGNN(nn.Module):
         return torch.softmax(logits, dim=-1)
 
     def clf(self, x):
+        """
+        Classify the input node features.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input node features.
+
+        Returns
+        -------
+        torch.Tensor
+            Output node features.
+        """
         return self.cad_clf(x)

--- a/graphmuse/nn/models/pitch_spelling.py
+++ b/graphmuse/nn/models/pitch_spelling.py
@@ -167,9 +167,41 @@ class PitchEncoder(object):
 
 
 class PitchSpellingGNN(nn.Module):
-    def __init__(self, in_feats, n_hidden, out_feats_enc, n_layers, metadata, dropout=0.5, add_seq=False):
+    """
+    Pitch Spelling GNN model that uses MetricalGNN for pitch spelling prediction.
+
+    Parameters
+    ----------
+    input_channels : int
+        Number of input channels.
+    n_hidden : int
+        Number of hidden channels.
+    out_feats_enc : int
+        Number of output channels for the encoder.
+    n_layers : int
+        Number of layers.
+    metadata : dict
+        Metadata of the graph.
+    dropout : float, optional
+        Dropout rate, by default 0.5.
+    add_seq : bool, optional
+        Whether to add sequential processing, by default False.
+
+    Examples
+    --------
+    >>> model = PitchSpellingGNN(input_channels=16, n_hidden=32, out_feats_enc=64, n_layers=3, metadata=metadata)
+    >>> x_dict = {"note": torch.randn(10, 16)}
+    >>> edge_index_dict = {"note": torch.randint(0, 10, (2, 20))}
+    >>> neighbor_mask_node = {"note": torch.zeros(10, dtype=torch.long)}
+    >>> neighbor_mask_edge = {"note": torch.zeros(20, dtype=torch.long)}
+    >>> batch = torch.zeros(10, dtype=torch.long)
+    >>> out_pc, out_ks = model(x_dict, edge_index_dict, neighbor_mask_node, neighbor_mask_edge, batch)
+    >>> print(out_pc.shape, out_ks.shape)
+    torch.Size([10, 64]) torch.Size([10, 15])
+    """
+    def __init__(self, input_channels, n_hidden, out_feats_enc, n_layers, metadata, dropout=0.5, add_seq=False):
         super(PitchSpellingGNN, self).__init__()
-        self.gnn_enc = MetricalGNN(in_feats, n_hidden, out_feats_enc, n_layers, metadata, dropout=dropout)
+        self.gnn_enc = MetricalGNN(input_channels, n_hidden, out_feats_enc, n_layers, metadata, dropout=dropout)
         self.normalize = gnn.GraphNorm(out_feats_enc)
         self.add_seq = add_seq
         self.pitch_label_encoder = PitchEncoder()
@@ -178,7 +210,7 @@ class PitchSpellingGNN(nn.Module):
         out_feats_ks = self.key_label_encoder.encode_dim
         if add_seq:
             self.rnn = nn.GRU(
-                input_size=in_feats,
+                input_size=input_channels,
                 hidden_size=n_hidden // 2,
                 bidirectional=True,
                 num_layers=1,
@@ -214,6 +246,23 @@ class PitchSpellingGNN(nn.Module):
         )
 
     def sequential_forward(self, note, neighbor_mask_node, batch):
+        """
+        Forward pass for sequential processing of pitch spelling.
+
+        Parameters
+        ----------
+        note : torch.Tensor
+            Input note features.
+        neighbor_mask_node : dict
+            Dictionary of neighbor mask for nodes.
+        batch : torch.Tensor
+            Batch indices.
+
+        Returns
+        -------
+        torch.Tensor
+            Output note features after sequential processing.
+        """
         z = note[neighbor_mask_node["note"] == 0]
         lengths = torch.bincount(batch)
         z = z.split(lengths.tolist())
@@ -226,6 +275,21 @@ class PitchSpellingGNN(nn.Module):
         return z
 
     def sequential_ks_forward(self, x, batch):
+        """
+        Forward pass for sequential processing of key signature.
+
+        Parameters
+        ----------
+        x : torch.Tensor
+            Input features.
+        batch : torch.Tensor
+            Batch indices.
+
+        Returns
+        -------
+        torch.Tensor
+            Output features after sequential processing.
+        """
         lengths = torch.bincount(batch)
         x = x.split(lengths.tolist())
         x = nn.utils.rnn.pad_sequence(x, batch_first=True)
@@ -237,6 +301,27 @@ class PitchSpellingGNN(nn.Module):
         return x
 
     def forward(self, x_dict, edge_index_dict, neighbor_mask_node=None, neighbor_mask_edge=None, batch=None):
+        """
+        Forward pass of the Pitch Spelling GNN model.
+
+        Parameters
+        ----------
+        x_dict : dict
+            Dictionary of node features.
+        edge_index_dict : dict
+            Dictionary of edge indices.
+        neighbor_mask_node : dict, optional
+            Dictionary of neighbor mask for nodes, by default None.
+        neighbor_mask_edge : dict, optional
+            Dictionary of neighbor mask for edges, by default None.
+        batch : torch.Tensor, optional
+            Batch indices, by default None.
+
+        Returns
+        -------
+        tuple
+            Tuple of pitch class and key signature predictions.
+        """
         x = self.gnn_enc(x_dict, edge_index_dict, neighbor_mask_node, neighbor_mask_edge)
         x = self.normalize(x, batch=batch)
         if self.add_seq:

--- a/graphmuse/utils/graph.py
+++ b/graphmuse/utils/graph.py
@@ -9,6 +9,25 @@ from typing import Optional, Union, Tuple, List, Dict, Any
 
 
 def graph_to_pyg(x, edge_index, edge_attributes=None, note_array=None):
+    """
+    Convert graph data to PyTorch Geometric HeteroData format.
+
+    Parameters
+    ----------
+    x : np.ndarray or torch.Tensor
+        Node features.
+    edge_index : np.ndarray
+        Edge indices.
+    edge_attributes : np.ndarray, optional
+        Edge attributes, by default None.
+    note_array : np.ndarray, optional
+        Note array, by default None.
+
+    Returns
+    -------
+    HeteroData
+        PyTorch Geometric HeteroData object.
+    """
     edge_type_map = {"onset": 0, "consecutive": 1, "during": 2, "rest": 3}
     data = HeteroData()
     data["note"].x = torch.from_numpy(x) if isinstance(x, np.ndarray) else x
@@ -25,7 +44,8 @@ def graph_to_pyg(x, edge_index, edge_attributes=None, note_array=None):
 
 
 def edges_from_note_array(note_array):
-    '''Turn note_array to list of edges.
+    """
+    Turn note_array to list of edges.
 
     Parameters
     ----------
@@ -34,10 +54,9 @@ def edges_from_note_array(note_array):
 
     Returns
     -------
-    edg_src : np.array
+    np.ndarray
         The edges in the shape of (2, num_edges).
-    '''
-
+    """
     edg_src = list()
     edg_dst = list()
     start_rest_index = len(note_array)
@@ -80,6 +99,11 @@ def add_reverse_edges(graph, mode):
         The graph object.
     mode : str
         The mode of adding reverse edges. Either 'new_type' or 'undirected'.
+
+    Returns
+    -------
+    HeteroData
+        The graph with added reverse edges.
     """
     if mode == "new_type":
         # add reversed consecutive edges
@@ -102,6 +126,23 @@ def add_reverse_edges(graph, mode):
 
 
 def add_reverse_edges_from_edge_index(edge_index, edge_type, mode="new_type"):
+    """
+    Add reverse edges to the edge index.
+
+    Parameters
+    ----------
+    edge_index : torch.Tensor
+        Edge indices.
+    edge_type : torch.Tensor
+        Edge types.
+    mode : str, optional
+        The mode of adding reverse edges, by default "new_type".
+
+    Returns
+    -------
+    Tuple[torch.Tensor, torch.Tensor]
+        Updated edge indices and edge types.
+    """
     if mode == "new_type":
         unique_edge_types = torch.unique(edge_type)
         for type in unique_edge_types:
@@ -116,7 +157,21 @@ def add_reverse_edges_from_edge_index(edge_index, edge_type, mode="new_type"):
 
 
 def add_measure_nodes(measures, note_array):
-    """Add virtual nodes for every measure"""
+    """
+    Add virtual nodes for every measure.
+
+    Parameters
+    ----------
+    measures : np.ndarray or list
+        Measures data.
+    note_array : np.ndarray
+        Note array.
+
+    Returns
+    -------
+    Tuple[np.ndarray, np.ndarray, int]
+        Measure cluster, measure edges, and number of measures.
+    """
     assert "onset_div" in note_array.dtype.names, "Note array must have 'onset_div' field to add measure nodes."
     if not isinstance(measures, np.ndarray):
         measures = np.array([[m.start.t, m.end.t] for m in measures])
@@ -148,9 +203,22 @@ def add_measure_nodes(measures, note_array):
 
     return measure_cluster, measure_edges, num_measures
 
+
 def add_beat_nodes(note_array):
-    """Add virtual nodes for every beat"""
-    assert "onset_beat" in note_array.dtype.names, "Note array must have 'onset_beat' field to add measure nodes."
+    """
+    Add virtual nodes for every beat.
+
+    Parameters
+    ----------
+    note_array : np.ndarray
+        Note array.
+
+    Returns
+    -------
+    Tuple[np.ndarray, np.ndarray, np.ndarray]
+        Beat cluster, beat index, and beat edges.
+    """
+    assert "onset_beat" in note_array.dtype.names, "Note array must have 'onset_beat' field to add beat nodes."
     # when the onset_beat has negative values, we need to shift all the values to be positive
     onset_beat = note_array["onset_beat"]
     # beat_edges, beat_index, beat_cluster = csamplers.compute_beat_edges(onset_beat)
@@ -190,7 +258,8 @@ def create_score_graph(
         add_reverse: bool= True,
         measures: Optional[List[spt.Measure]] = None,
         add_beats: bool = False) -> HeteroData:
-    """Create a score graph from note array.
+    """
+    Create a score graph from note array.
 
     Parameters
     ----------
@@ -212,7 +281,7 @@ def create_score_graph(
 
     Returns
     -------
-    graph : HeteroData
+    HeteroData
         The score graph.
     """
     if sort:

--- a/graphmuse/utils/graph.py
+++ b/graphmuse/utils/graph.py
@@ -206,7 +206,7 @@ def add_measure_nodes(measures, note_array):
 
 def add_beat_nodes(note_array):
     """
-    Add virtual nodes for every beat.
+    Add virtual nodes for every measure.
 
     Parameters
     ----------


### PR DESCRIPTION
Fixes #11

Add numpy doc style docstrings and uniform variable names in models.

* **graphmuse/loader/neighbor_loader.py**
  - Change `in_dim` to `input_channels` in `MuseNeighborLoader` class.
  - Add numpy doc style docstrings to `MuseNeighborLoader` class methods.
  - Add examples to docstrings where needed in `MuseNeighborLoader` class.

* **graphmuse/nn/conv/gat.py**
  - Change `in_dim` to `input_channels` in `GraphAttentionLayer` class.
  - Add numpy doc style docstrings to `GraphAttentionLayer` class methods.
  - Add examples to docstrings where needed in `GraphAttentionLayer` class.

* **graphmuse/nn/conv/gcn.py**
  - Change `in_dim` to `input_channels` in `GraphConv` class.
  - Add numpy doc style docstrings to `GraphConv` class methods.
  - Add examples to docstrings where needed in `GraphConv` class.

* **graphmuse/nn/conv/ggru.py**
  - Change `in_features` to `input_channels` in `GGRU` class.
  - Add numpy doc style docstrings to `GGRU` class methods.
  - Add examples to docstrings where needed in `GGRU` class.

* **graphmuse/nn/conv/metrical_conv.py**
  - Change `in_dim` to `input_channels` in `MetricalConvLayer` class.
  - Add numpy doc style docstrings to `MetricalConvLayer` class methods.
  - Add examples to docstrings where needed in `MetricalConvLayer` class.

* **graphmuse/nn/conv/musgconv.py**
  - Change `in_channels` to `input_channels` in `MusGConv` class.
  - Add numpy doc style docstrings to `MusGConv` class methods.
  - Add examples to docstrings where needed in `MusGConv` class.

